### PR TITLE
Change default encoding and allow folder exclusions

### DIFF
--- a/strangethings.conf-SAMPLE
+++ b/strangethings.conf-SAMPLE
@@ -32,4 +32,15 @@ windowsbin = exe,dll,com
 
 
 
+[excludedirs]
+
+# Define a list of directories to exlude from the search. An exclusion list
+# can be selected by using the "-e EXCLUDEDIRS" flag. On a NetApp filer for example
+# you'll want to exclude snapshots from the search.
+#
+# Example:       netapp = ~snapshot
+
+netapp = ~snapshot
+
+
 


### PR DESCRIPTION
Sets the default encoding type from ASCII to UTF-8 for Python 2.x in order to support complex filenames.
Added the possibility to define folders which are excluded from the search. (Like a snapshot directory or recycle bin).
